### PR TITLE
Fixed format_long and format_price implementation and usage 

### DIFF
--- a/lib/evecentral/evec_func.py
+++ b/lib/evecentral/evec_func.py
@@ -47,46 +47,14 @@ class SorterDict(dict):
 
 
 def format_long(price):
-
-    intpart = long(price)
-    intpart = list(str(intpart))
-
-    if price >= 1000:
-        intpart.insert(len(intpart)-3, ',')
-    if price >= 1000000:
-        intpart.insert(len(intpart)-7, ',')
-    if price >= 1000000000:
-        intpart.insert(len(intpart)-11, ',')
-
-    string = ""
-    for x in intpart:
-        string = string + x
-
-    return string
+    formatted = '{:,}'.format(long(price))
+    return formatted
 
 
 def format_price(price):
-    price = float(price)
-    intpart = long(price)
-    intpart = list(str(intpart))
+    formatted = '{:,.2f}'.format(pp)
+    return formatted
 
-    if price >= 1000:
-        intpart.insert(len(intpart)-3, ',')
-    if price >= 1000000:
-        intpart.insert(len(intpart)-7, ',')
-    if price >= 1000000000:
-        intpart.insert(len(intpart)-11, ',')
-
-    string = ""
-    for x in intpart:
-        string = string + x
-
-    price = price - long(price)
-    price = list(str("%f.2" % price))
-    for x in price[1:4]:
-        string = string + x
-
-    return string
 
 class EVCstate:
     def __init__(self, trust=False):
@@ -124,50 +92,6 @@ def simple_error(message):
     mess += "<h3>Error</h3>" + message
     mess += "</body></html>"
     return mess
-
-
-def format_long(price):
-
-    intpart = long(price)
-    intpart = list(str(intpart))
-
-    if price >= 1000:
-        intpart.insert(len(intpart)-3, ',')
-    if price >= 1000000:
-        intpart.insert(len(intpart)-7, ',')
-    if price >= 1000000000:
-        intpart.insert(len(intpart)-11, ',')
-
-    string = ""
-    for x in intpart:
-        string = string + x
-
-    return string
-
-
-def format_price(price):
-    price = float(price)
-    intpart = long(price)
-    intpart = list(str(intpart))
-
-    if price >= 1000:
-        intpart.insert(len(intpart)-3, ',')
-    if price >= 1000000:
-        intpart.insert(len(intpart)-7, ',')
-    if price >= 1000000000:
-        intpart.insert(len(intpart)-11, ',')
-
-    string = ""
-    for x in intpart:
-        string = string + x
-
-    price = price - long(price)
-    price = list(str("%f.2" % price))
-    for x in price[1:4]:
-        string = string + x
-
-    return string
-
 
 def build_regionquery(front,rl_o):
 

--- a/lib/evecentral/evec_func.py
+++ b/lib/evecentral/evec_func.py
@@ -52,7 +52,7 @@ def format_long(price):
 
 
 def format_price(price):
-    formatted = '{:,.2f}'.format(pp)
+    formatted = '{:,.2f}'.format(price)
     return formatted
 
 

--- a/web/evec.py
+++ b/web/evec.py
@@ -261,7 +261,7 @@ class Home:
                     # Try to grab regionid from the end of the query
                     if isbuy:
                         if int(r[11]) > 1:
-                            rec['minvolume'] = format_long(int(r[11]))
+                            rec['minvolume'] = format_long(r[11])
                             rec['minvolume_raw'] = int(r[11])
                         else:
                             rec['minvolume'] = 1
@@ -498,18 +498,18 @@ class Home:
                 row['to2'] = int(r[3])
                 row['fromstation'] = r[4]
                 row['tostation'] = r[5]
-                row['pricediff'] = r[6]
-                row['tradeable'] = format_long(long(r[7]))
-                row['profit'] = format_price(float(r[8]))
+                row['pricediff'] = format_price(r[6])
+                row['tradeable'] = format_long(r[7])
+                row['profit'] = format_price(r[8])
                 row['profit_num'] = float(r[8])
                 row['profit_size'] = float(r[9])
                 from_set.add(fr)
 
 
-                row['tprice'] = format_price(float(r[11]))
-                row['fprice'] = format_price(float(r[12]))
-                row['tvol'] = format_long(long(r[13]))
-                row['fvol'] = format_long(long(r[14]))
+                row['tprice'] = format_price(r[11])
+                row['fprice'] = format_price(r[12])
+                row['tvol'] = format_long(r[13])
+                row['fvol'] = format_long(r[14])
                 trades.append(row)
 
                 # Add to from_to_map - map source
@@ -568,7 +568,7 @@ class Home:
                             row['sortby'] = distance
                             row.reverse= True
 
-                        row['profit_jumps'] = format_price(float(ps/(1+max(0,distance))))
+                        row['profit_jumps'] = format_price(ps/(1+max(0,distance)))
                         row['distance'] = distance
 
 


### PR DESCRIPTION
It is all fairly straight forward, information about the str.format() function can be found at https://docs.python.org/2/library/string.html#formatspec. Casting the variables to longs/floats before passing them into format_long/format_price is no longer needed, so it was removed.
## 

If possible make sure this is tested before it is put into deployment, as the virtualenv was not working for me.
